### PR TITLE
Disable Unnecessary Default Workflows and Enable Only Colcon Build Main CI

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,9 +1,6 @@
 name: backport
 on:
-  pull_request_target:
-    types:
-      - closed
-      - labeled
+  workflow_dispatch
 
 jobs:
   backport:

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -1,8 +1,6 @@
 name: build-main-self-hosted
 
 on:
-  schedule:
-    - cron: 0 12 * * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -1,7 +1,7 @@
 name: cancel-previous-workflows
 
 on:
-  pull_request_target:
+  workflow_dispatch
 
 jobs:
   cancel-previous-workflows:

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -1,13 +1,7 @@
 name: docker-build-and-push-main-self-hosted
 
 on:
-  push:
-    tags:
-      - v*
-      - "[0-9]+.[0-9]+*"
-  schedule:
-    - cron: 0 0 1,15 * *
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   docker-build-and-push-main-self-hosted:

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -1,13 +1,7 @@
 name: docker-build-and-push-main
 
 on:
-  push:
-    tags:
-      - v*
-      - "[0-9]+.[0-9]+*"
-  schedule:
-    - cron: 0 0 1,15 * *
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   docker-build-and-push-main:

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -1,17 +1,7 @@
 name: github-release
 
 on:
-  push:
-    branches:
-      - beta/v*
-    tags:
-      - v*
-  workflow_dispatch:
-    inputs:
-      beta-branch-or-tag-name:
-        description: The name of the beta branch or tag to release
-        type: string
-        required: true
+  workflow_dispatch
 
 jobs:
   github-release:

--- a/.github/workflows/load-env.yaml
+++ b/.github/workflows/load-env.yaml
@@ -1,12 +1,7 @@
 name: load-env
 
 on:
-  workflow_call:
-    outputs:
-      base-image:
-        value: ${{ jobs.load-env.outputs.base-image }}
-      rosdistro:
-        value: ${{ jobs.load-env.outputs.rosdistro }}
+  workflow_dispatch
 
 jobs:
   load-env:

--- a/.github/workflows/mirror-main-branch.yaml
+++ b/.github/workflows/mirror-main-branch.yaml
@@ -1,10 +1,7 @@
 name: mirror-main-branch
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   mirror-main-branch:

--- a/.github/workflows/pre-commit-ansible-autoupdate.yaml
+++ b/.github/workflows/pre-commit-ansible-autoupdate.yaml
@@ -1,9 +1,7 @@
 name: pre-commit-ansible-autoupdate
 
 on:
-  schedule:
-    - cron: 0 0 * * *
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   check-secret:

--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -1,7 +1,7 @@
 name: pre-commit-ansible
 
 on:
-  pull_request:
+  workflow_dispatch
 
 jobs:
   pre-commit-ansible:

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -1,9 +1,7 @@
 name: pre-commit-autoupdate
 
 on:
-  schedule:
-    - cron: 0 0 * * *
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   check-secret:

--- a/.github/workflows/pre-commit-optional-autoupdate.yaml
+++ b/.github/workflows/pre-commit-optional-autoupdate.yaml
@@ -1,9 +1,7 @@
 name: pre-commit-optional-autoupdate
 
 on:
-  schedule:
-    - cron: 0 0 * * *
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   check-secret:

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -1,7 +1,7 @@
 name: pre-commit-optional
 
 on:
-  pull_request:
+  workflow_dispatch
 
 jobs:
   pre-commit-optional:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,7 +1,7 @@
 name: pre-commit
 
 on:
-  pull_request:
+  workflow_dispatch
 
 jobs:
   pre-commit:

--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -1,11 +1,7 @@
 name: semantic-pull-request
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+  workflow_dispatch
 
 jobs:
   semantic-pull-request:

--- a/.github/workflows/setup-docker.yaml
+++ b/.github/workflows/setup-docker.yaml
@@ -1,7 +1,7 @@
 name: setup-docker
 
 on:
-  pull_request:
+  workflow_dispatch
 
 jobs:
   load-env:

--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -1,7 +1,7 @@
 name: setup-universe
 
 on:
-  pull_request:
+  workflow_dispatch
 
 jobs:
   load-env:

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -1,7 +1,7 @@
 name: spell-check-differential
 
 on:
-  pull_request:
+  workflow_dispatch
 
 jobs:
   spell-check-differential:

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -1,9 +1,7 @@
 name: sync-files
 
 on:
-  schedule:
-    - cron: 0 0 * * *
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   check-secret:

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -1,9 +1,7 @@
 name: update-docker-manifest
 
 on:
-  schedule:
-    - cron: 0 0 * * *
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   load-env:

--- a/.github/workflows/update-tool-versions.yaml
+++ b/.github/workflows/update-tool-versions.yaml
@@ -1,9 +1,7 @@
 name: update-tool-versions
 
 on:
-  schedule:
-    - cron: 0 0 * * *
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   update-tool-versions:

--- a/.github/workflows/vcs-import.yaml
+++ b/.github/workflows/vcs-import.yaml
@@ -1,8 +1,7 @@
 name: vcs-import
 
 on:
-  pull_request:
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   load-env:


### PR DESCRIPTION
This PR aims to streamline our CI processes by disabling several default workflows inherited from the source Autoware repository. Currently, these workflows are not needed for our project, and disabling them will reduce unnecessary build and test cycles.

Key changes include:

	•	Disabling all default workflows from the source Autoware repository.
	•	Ensuring that only the essential colcon build main CI workflow is triggered upon any commits or pull requests.