### PR TITLE
[feat]Add S3 Upload and Greengrass Deployment Workflow for Autoware.repos Updates

### DIFF
--- a/.github/workflows/autoware-repos-to-s3.yaml
+++ b/.github/workflows/autoware-repos-to-s3.yaml
@@ -1,4 +1,4 @@
-name: Upload to S3 with Versioning
+name: Upload to S3 and Deploy to Greengrass
 
 on:
   push:
@@ -8,10 +8,14 @@ on:
       - 'autoware.repos'
 
 jobs:
-  upload:
+  upload-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Verify AWS Credentials
+        run: |
+          aws sts get-caller-identity
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -26,4 +30,15 @@ jobs:
           aws s3 cp autoware.repos s3://lomby-greengrass/autoware-repos-updates/latest/autoware.repos
           aws s3 cp autoware.repos s3://lomby-greengrass/autoware-repos-updates/archive/$TIMESTAMP-autoware.repos
 
+      - name: Create Greengrass Deployment
+        run: |
+          aws greengrassv2 create-deployment \
+            --target-arn arn:aws:iot:ap-northeast-1:${{ secrets.AWS_ACCOUNT_ID }}:thinggroup/${{ secrets.THING_GROUP_NAME }} \
+            --deployment-name "AutowareReposUpdate-$(date +%Y-%m-%d-%H-%M-%S)" \
+            --components '{"AutowareReposUpdater": {"componentVersion": "1.0.0"}}' \
+            --region ap-northeast-1
 
+      - name: Check Deployment Status
+        run: |
+          DEPLOYMENT_ID=$(aws greengrassv2 list-deployments --target-arn arn:aws:iot:ap-northeast-1:${{ secrets.AWS_ACCOUNT_ID }}:thinggroup/${{ secrets.THING_GROUP_NAME }} --query 'deployments[0].deploymentId' --output text)
+          aws greengrassv2 get-deployment --deployment-id $DEPLOYMENT_ID

--- a/.github/workflows/autoware-repos-to-s3.yaml
+++ b/.github/workflows/autoware-repos-to-s3.yaml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Verify AWS Credentials
-        run: |
-          aws sts get-caller-identity
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/autoware-repos-to-s3.yaml
+++ b/.github/workflows/autoware-repos-to-s3.yaml
@@ -1,9 +1,10 @@
 name: Upload to S3 and Deploy to Greengrass
 
-on:
-  push:
-    branches:
-      - feat/MAS-508
+on: workflow_dispatch
+  # uncomment below to enable the workflow
+  # push:
+  #   branches:
+  #     - release/lomby/2024.10/2024.12
     paths:
       - 'autoware.repos'
 

--- a/.github/workflows/autoware-repos-to-s3.yaml
+++ b/.github/workflows/autoware-repos-to-s3.yaml
@@ -1,0 +1,29 @@
+name: Upload to S3 with Versioning
+
+on:
+  push:
+    branches:
+      - feat/MAS-508
+    paths:
+      - 'autoware.repos'
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - name: Upload new 'autoware.repos' file to 'latest' and 'archive'
+        run: |
+          TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+          aws s3 cp autoware.repos s3://lomby-greengrass/autoware-repos-updates/latest/autoware.repos
+          aws s3 cp autoware.repos s3://lomby-greengrass/autoware-repos-updates/archive/$TIMESTAMP-autoware.repos
+
+

--- a/.github/workflows/autoware-repos-to-s3.yaml
+++ b/.github/workflows/autoware-repos-to-s3.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Create Greengrass Deployment
         run: |
           aws greengrassv2 create-deployment \
-            --target-arn arn:aws:iot:ap-northeast-1:${{ secrets.AWS_ACCOUNT_ID }}:thinggroup/${{ secrets.THING_GROUP_NAME }} \
+            --target-arn arn:aws:iot:ap-northeast-1:${{ secrets.AWS_ACCOUNT_ID }}:thinggroup/lomby-lma2-things \
             --deployment-name "AutowareReposUpdate-$(date +%Y-%m-%d-%H-%M-%S)" \
             --components '{"AutowareReposUpdater": {"componentVersion": "1.0.0"}}' \
             --region ap-northeast-1

--- a/.github/workflows/autoware-repos-to-s3.yaml
+++ b/.github/workflows/autoware-repos-to-s3.yaml
@@ -36,5 +36,5 @@ jobs:
 
       - name: Check Deployment Status
         run: |
-          DEPLOYMENT_ID=$(aws greengrassv2 list-deployments --target-arn arn:aws:iot:ap-northeast-1:${{ secrets.AWS_ACCOUNT_ID }}:thinggroup/${{ secrets.THING_GROUP_NAME }} --query 'deployments[0].deploymentId' --output text)
+          DEPLOYMENT_ID=$(aws greengrassv2 list-deployments --target-arn arn:aws:iot:ap-northeast-1:${{ secrets.AWS_ACCOUNT_ID }}:thinggroup/lomby-lma2-things --query 'deployments[0].deploymentId' --output text)
           aws greengrassv2 get-deployment --deployment-id $DEPLOYMENT_ID

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,5 +1,4 @@
 repositories:
-
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,4 +1,5 @@
 repositories:
+
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,6 +1,4 @@
 repositories:
-
-
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,4 +1,6 @@
 repositories:
+
+
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git


### PR DESCRIPTION
## Description

This PR adds a new GitHub Actions workflow to automate the upload of `autoware.repos` to S3 and deploy updates to Greengrass devices. It includes automated S3 uploads, Greengrass deployment initiation, and status verification. The workflow can be triggered automatically on pushes or manually.

JIRA Ticket: MAS-508

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Tested workflow execution on a test branch
- [ ] Verified S3 uploads and Greengrass deployments
Verified with github actions [run#4](https://github.com/lomby-inc/autoware/actions/runs/12986493619/job/36213430511), works as expected:
autoware.repos updated in github repo > action workflow triggered > autoware.repos file copied from repo to s3 bucket [lomby-greengrass/autoware-repos-updates/latest](https://ap-northeast-1.console.aws.amazon.com/s3/buckets/lomby-greengrass?region=ap-northeast-1&bucketType=general&prefix=autoware-repos-updates/latest/&showversions=false) > also taking backup for same file in archieve [2025-01-27_08-42-57-autoware.repos](https://ap-northeast-1.console.aws.amazon.com/s3/object/lomby-greengrass?region=ap-northeast-1&bucketType=general&prefix=autoware-repos-updates/archive/2025-01-27_08-42-57-autoware.repos) > then does the automatic deployment in greengrass console > monitors the deployment progress

## Checklist

- [x] Code follows project style guidelines
- [x] Code is commented and documented
- [ ] Tests added and passing
- [x] No new warnings generated